### PR TITLE
Refactor maintenance parameter table to use QTableWidget

### DIFF
--- a/MaintWindow.py
+++ b/MaintWindow.py
@@ -1,5 +1,9 @@
-from PyQt6.QtGui import QStandardItemModel, QStandardItem
-from PyQt6.QtWidgets import QMainWindow, QPushButton, QTableView, QTableWidgetItem, QTableWidget
+from PyQt6.QtWidgets import (
+    QMainWindow,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+)
 from PyQt6 import uic
 
 class MaintenanceWindow(QMainWindow):
@@ -8,8 +12,8 @@ class MaintenanceWindow(QMainWindow):
         uic.loadUi("Maintenance_Window.ui", self)  # Load the .ui file
         self.setWindowTitle("Maintenance Window")
         self.showMaximized()
-        self.btn_ret_main_screen =self.findChild(QPushButton, "btn_RetMainScreen")
-        self.tbl_parameters = self.findChild(QTableView, "tbl_parameters")
+        self.btn_ret_main_screen = self.findChild(QPushButton, "btn_RetMainScreen")
+        self.tbl_parameters = self.findChild(QTableWidget, "tbl_parameters")
 
         print(self.btn_ret_main_screen)
         self.btn_ret_main_screen.clicked.connect(self.ret2main)
@@ -18,25 +22,13 @@ class MaintenanceWindow(QMainWindow):
         self.close()
 
     def update_tbl_parameters(self):
-        try:
-            self.data = [('test1', 'test2'), ('test3', 'test4')]
+        self.data = [("test1", "test2"), ("test3", "test4")]
 
-            # 1. Create a model
-            model = QStandardItemModel(len(self.data), len(self.data[0]))
+        self.tbl_parameters.setRowCount(len(self.data))
+        self.tbl_parameters.setColumnCount(len(self.data[0]))
+        self.tbl_parameters.setHorizontalHeaderLabels(["Column 1", "Column 2"])
 
-            # Optional: Set header labels
-            model.setHorizontalHeaderLabels(['Column 1', 'Column 2'])
-
-            # 2. Populate the model with data
-            for row_index, row_data in enumerate(self.data):
-                for col_index, cell_data in enumerate(row_data):
-                    item = QStandardItem(cell_data)
-                    model.setItem(row_index, col_index, item)
-
-            # 3. Set the model on the QTableView from your UI file
-            self.tbl_parameters.setModel(model)
-
-        except Exception as e:
-            # Assuming you have this method, otherwise just use print()
-            #self.log_to_terminal(f"Failed to update table: {e}", level="error")
-            print(f'Error: {e}')
+        for row_index, row_data in enumerate(self.data):
+            for col_index, cell_data in enumerate(row_data):
+                item = QTableWidgetItem(cell_data)
+                self.tbl_parameters.setItem(row_index, col_index, item)


### PR DESCRIPTION
## Summary
- Switch MaintenanceWindow's parameter table to QTableWidget and populate using QTableWidgetItem
- Remove QStandardItemModel usage and broad exception handling

## Testing
- `python -m py_compile MaintWindow.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71d79844c8328a42dc9ee7072df32